### PR TITLE
Minor 4004 history changes

### DIFF
--- a/src/content/chapters/1-the-basics.mdx
+++ b/src/content/chapters/1-the-basics.mdx
@@ -14,7 +14,7 @@ Let's start with the basics of how your computer works at its very core.
 
 The *central processing unit* (CPU) of a computer is in charge of all computation. It's the big cheese. The shazam alakablam. It starts chugging as soon as you start your computer, executing instruction after instruction after instruction.
 
-The first mass-produced CPU was the [Intel 4004](http://www.intel4004.com/), designed in the late 60s by an Italian physicist and engineer named Federico Faggin. It was a 4-bit architecture instead of the [64-bit](https://en.wikipedia.org/wiki/64-bit_computing) systems we use today, and it was far less complex than modern processors, but a lot of its simplicity does still remain.
+The first microprocessor CPU was the [Intel 4004](http://www.intel4004.com/), designed in the early 70s by an Italian physicist and engineer named Federico Faggin. It was a 4-bit architecture instead of the [64-bit](https://en.wikipedia.org/wiki/64-bit_computing) systems we use today, and it was far less complex than modern processors, but a lot of its simplicity does still remain.
 
 The "instructions" that CPUs execute are just binary data: a byte or two to represent what instruction is being run (the opcode), followed by whatever data is needed to run the instruction. What we call *machine code* is nothing but a series of these binary instructions in a row. [Assembly](https://en.wikipedia.org/wiki/Assembly_language) is a helpful syntax for reading and writing machine code that's easier for humans to read and write than raw bits; it is always compiled to the binary that your CPU knows how to read.
 


### PR DESCRIPTION
A couple of minor history notes if it's okay.
The 4004 project started in 1969 but Faggin didn't join Intel until April 1970, so most of the design work was in the early 1970s.

There were mass-produced CPUs back in the 1950s for mainframes and later for minicomputers.